### PR TITLE
Add Zappi phase setting support (1/3/auto)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "myenergi-api",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "myenergi-api",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "license": "MIT",
             "devDependencies": {
                 "@jest/test-sequencer": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "myenergi-api",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "NodeJS implementation of MyEnergi API for controlling Zappi, Eddi and other MyEnergi products",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/MyEnergi.ts
+++ b/src/MyEnergi.ts
@@ -4,7 +4,7 @@ import { AppKeyValues } from './models/AppKeyValues';
 import { Eddi } from "./models/Eddi";
 import { Harvi } from "./models/Harvi";
 import { KeyValue } from './models/KeyValue';
-import { EddiBoost, EddiMode, ZappiBoostMode, ZappiChargeMode } from "./models/Types";
+import { EddiBoost, EddiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting } from "./models/Types";
 import { Zappi } from "./models/Zappi";
 
 export class MyEnergi {
@@ -19,6 +19,7 @@ export class MyEnergi {
         dayhour_url: "/cgi-jdayhour-",
         zappi_mode_url: "/cgi-zappi-mode-Z",
         zappi_min_green_url: "/cgi-set-min-green-Z",
+        zappi_phase_setting_url: "/cgi-zappi-phase-setting-Z",
         zappi_boost_time_url: "/cgi-boost-time-Z",
         eddi_mode_url: "/cgi-eddi-mode-E",
         eddi_boost_url: "/cgi-eddi-boost-E",
@@ -108,6 +109,21 @@ export class MyEnergi {
             const jsonData = JSON.parse(data);
             return jsonData;
         } catch (error) {            
+            return {};
+        }
+    }
+
+    /**
+     * Set the phase setting on a Zappi. Requires firmware with phase
+     * switching support (three phase Zappi V2.1 and later).
+     */
+    public async setZappiPhaseSetting(serialNo: string, phaseSetting: ZappiPhaseSetting): Promise<any> {
+        try {
+            const url = new URL(`${this._config.zappi_phase_setting_url}${serialNo}-${phaseSetting}`, this._config.base_url);
+            const data = await this._digest.get(url);
+            const jsonData = JSON.parse(data);
+            return jsonData;
+        } catch (error) {
             return {};
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Eddi } from "./models/Eddi";
 import { Harvi } from "./models/Harvi";
-import { EddiBoost, EddiHeaterStatus, EddiMode, ZappiBoostMode, ZappiChargeMode, ZappiStatus } from "./models/Types";
+import { EddiBoost, EddiHeaterStatus, EddiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus } from "./models/Types";
 import { Zappi } from "./models/Zappi";
 import { MyEnergi } from "./MyEnergi";
-export { MyEnergi, Eddi, Zappi, Harvi, EddiBoost, EddiMode, EddiHeaterStatus, ZappiBoostMode, ZappiChargeMode, ZappiStatus };
+export { MyEnergi, Eddi, Zappi, Harvi, EddiBoost, EddiMode, EddiHeaterStatus, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus };

--- a/src/models/Types.ts
+++ b/src/models/Types.ts
@@ -57,3 +57,18 @@ export enum ZappiStatus {
     Charging = "C2",
     Fault = "F",
 }
+
+export enum ZappiPhaseSetting {
+    /**
+     * Charge using a single phase.
+     */
+    SinglePhase = 0,
+    /**
+     * Charge using all three phases.
+     */
+    ThreePhase = 1,
+    /**
+     * Let the Zappi switch between single and three phase automatically.
+     */
+    Auto = 2,
+}

--- a/src/models/Zappi.ts
+++ b/src/models/Zappi.ts
@@ -399,4 +399,13 @@ export interface Zappi {
     rrac: number;
     zs: number;
     zsl: number;
+
+    /**
+     * Phase setting reported by newer Zappi firmware.
+     * "1" = single phase, "3" = three phase, "auto" = automatic switching.
+     * Not present on older firmware versions.
+     *
+     * @type {string}
+     */
+    phaseSetting?: string;
 }

--- a/tests/MyEnergi-spec.ts
+++ b/tests/MyEnergi-spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { MyEnergi } from "../src/MyEnergi";
+import { ZappiPhaseSetting } from "../src/models/Types";
 import nock from "nock";
 import { Zappi } from "../src/models/Zappi";
 import { AppKeyValues } from '../src/models/AppKeyValues';
@@ -185,6 +186,19 @@ describe("MyEnergi Tests", () => {
         const testResponse: KeyValue[] = response[Object.keys(response)[0]];
         expect(res).toMatchObject(testResponse);
         expect(testResponse[0].val).toMatch("Zappi123");
+        nock.cleanAll();
+    }, 60000);
+
+    it("Should set Zappi phase setting", async () => {
+        nock("https://test.com")
+            .defaultReplyHeaders({ "www-authenticate": "Digest realm=Example" })
+            .get("/cgi-zappi-phase-setting-Z12345678-2")
+            .reply(200, { status: 0, statustext: "" });
+
+        const query = new MyEnergi("test", "pwd", "https://test.com");
+
+        const res = await query.setZappiPhaseSetting("12345678", ZappiPhaseSetting.Auto);
+        expect(res).toMatchObject({ status: 0, statustext: "" });
         nock.cleanAll();
     }, 60000);
 


### PR DESCRIPTION
## Summary

- Adds `setZappiPhaseSetting(serialNo, ZappiPhaseSetting)` using the `cgi-zappi-phase-setting-Z<sno>-<n>` endpoint (0 = single phase, 1 = three phase, 2 = auto). Endpoint semantics match the community-proven implementation in pymyenergi (Home Assistant integration).
- New exported `ZappiPhaseSetting` enum.
- Optional `phaseSetting` field on the `Zappi` model ("1"/"3"/"auto", reported by newer firmware).
- Version bumped to 2.6.0.

Needed for bisand/net.biseth.myenergi#37 (switch Zappi between 1 and 3 phases from Homey flows).

## Testing

- New nock-based unit test; full suite passes (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)