### PR TITLE
Add getDayHourHistory for historic energy data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "myenergi-api",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "myenergi-api",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "license": "MIT",
             "devDependencies": {
                 "@jest/test-sequencer": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "myenergi-api",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "NodeJS implementation of MyEnergi API for controlling Zappi, Eddi and other MyEnergi products",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/MyEnergi.ts
+++ b/src/MyEnergi.ts
@@ -3,6 +3,7 @@ import { Digest } from "./Digest";
 import { AppKeyValues } from './models/AppKeyValues';
 import { Eddi } from "./models/Eddi";
 import { Harvi } from "./models/Harvi";
+import { HistoryRecord } from './models/HistoryRecord';
 import { KeyValue } from './models/KeyValue';
 import { EddiBoost, EddiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting } from "./models/Types";
 import { Zappi } from "./models/Zappi";
@@ -125,6 +126,39 @@ export class MyEnergi {
             return jsonData;
         } catch (error) {
             return {};
+        }
+    }
+
+    /**
+     * Retrieve historic energy data hour by hour for a device via
+     * cgi-jdayhour. All energy values in the returned records are in
+     * joules (watt seconds).
+     *
+     * @param id Device ID code: prefix letter plus serial number,
+     *           e.g. "Z12345678" for a Zappi or "E12345678" for an Eddi.
+     * @param year Year (four digits, UTC)
+     * @param month Month (1-12, UTC)
+     * @param day Day of month (UTC)
+     * @param startHour Optional starting hour (0-23, UTC)
+     * @param noHours Optional number of hours to report (default 24, max 744)
+     */
+    public async getDayHourHistory(id: string, year: number, month: number, day: number, startHour?: number, noHours?: number): Promise<HistoryRecord[]> {
+        try {
+            let path = `${this._config.dayhour_url}${id}-${year}-${month}-${day}`;
+            if (startHour !== undefined) {
+                path += `-${startHour}`;
+                if (noHours !== undefined) {
+                    path += `-${noHours}`;
+                }
+            }
+            const url = new URL(path, this._config.base_url);
+            const data = await this._digest.get(url);
+            const jsonData = JSON.parse(data);
+            const key = Object.keys(jsonData)[0];
+            const records = key ? jsonData[key] : undefined;
+            return Array.isArray(records) ? records as HistoryRecord[] : [];
+        } catch (error) {
+            return [];
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Eddi } from "./models/Eddi";
 import { Harvi } from "./models/Harvi";
+import { HistoryRecord } from "./models/HistoryRecord";
 import { EddiBoost, EddiHeaterStatus, EddiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus } from "./models/Types";
 import { Zappi } from "./models/Zappi";
 import { MyEnergi } from "./MyEnergi";
-export { MyEnergi, Eddi, Zappi, Harvi, EddiBoost, EddiMode, EddiHeaterStatus, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus };
+export { MyEnergi, Eddi, Zappi, Harvi, HistoryRecord, EddiBoost, EddiMode, EddiHeaterStatus, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus };

--- a/src/models/HistoryRecord.ts
+++ b/src/models/HistoryRecord.ts
@@ -1,0 +1,53 @@
+/**
+ * One row of historic telemetry from cgi-jdayhour (hourly) or cgi-jday /
+ * cgi-jhour (per minute). All energy values are in joules (watt seconds) -
+ * divide by 3600000 for kWh. Fields with value zero are omitted by the
+ * server, so all fields are optional.
+ */
+export interface HistoryRecord {
+    /** Minute (omitted on hourly records and when 0) */
+    min?: number;
+    /** Hour of day (UTC) */
+    hr?: number;
+    /** Day of week, three letter code e.g. "Mon" */
+    dow?: string;
+    /** Day of month */
+    dom?: number;
+    /** Month of year */
+    mon?: number;
+    /** Year (4 digits) */
+    yr?: number;
+    /** Imported energy (joules) */
+    imp?: number;
+    /** Exported energy (joules) */
+    exp?: number;
+    /** Positive generation energy (joules) */
+    gep?: number;
+    /** Negative generation energy (joules) */
+    gen?: number;
+    /** Energy diverted to heater/EV 1 (joules) */
+    h1d?: number;
+    /** Energy boosted to heater/EV 1 (joules) */
+    h1b?: number;
+    /** Energy diverted to heater/EV 2 (joules) */
+    h2d?: number;
+    /** Energy boosted to heater/EV 2 (joules) */
+    h2b?: number;
+    /** Energy diverted to heater/EV 3 (joules) */
+    h3d?: number;
+    /** Energy boosted to heater/EV 3 (joules) */
+    h3b?: number;
+    /** External CT 1-3 positive/negative energy (joules) */
+    pect1?: number;
+    nect1?: number;
+    pect2?: number;
+    nect2?: number;
+    pect3?: number;
+    nect3?: number;
+    /** Voltage phase 1 (0.1 V) */
+    v1?: number;
+    /** Mains frequency (0.01 Hz) */
+    frq?: number;
+    /** Pilot state (Zappi) */
+    pst?: string;
+}

--- a/tests/MyEnergi-spec.ts
+++ b/tests/MyEnergi-spec.ts
@@ -189,6 +189,27 @@ describe("MyEnergi Tests", () => {
         nock.cleanAll();
     }, 60000);
 
+    it("Should return day hour history records", async () => {
+        const historyResponse = {
+            "U12345678": [
+                { hr: 6, dow: "Mon", dom: 31, mon: 7, yr: 2023, imp: 3600000, h1d: 1800000 },
+                { hr: 7, dow: "Mon", dom: 31, mon: 7, yr: 2023, imp: 7200000, h1d: 3600000, h1b: 900000 },
+            ],
+        };
+        nock("https://test.com")
+            .defaultReplyHeaders({ "www-authenticate": "Digest realm=Example" })
+            .get("/cgi-jdayhour-Z12345678-2023-7-31-6-2")
+            .reply(200, historyResponse);
+
+        const query = new MyEnergi("test", "pwd", "https://test.com");
+
+        const res = await query.getDayHourHistory("Z12345678", 2023, 7, 31, 6, 2);
+        expect(res).toHaveLength(2);
+        expect(res[0].h1d).toBe(1800000);
+        expect(res[1].h1b).toBe(900000);
+        nock.cleanAll();
+    }, 60000);
+
     it("Should set Zappi phase setting", async () => {
         nock("https://test.com")
             .defaultReplyHeaders({ "www-authenticate": "Digest realm=Example" })


### PR DESCRIPTION
Adds `getDayHourHistory(id, year, month, day, startHour?, noHours?)` using the `cgi-jdayhour` endpoint, returning typed `HistoryRecord[]` (energy in joules, zero-suppressed fields optional). Needed for daily energy figures in bisand/net.biseth.myenergi#57 / #82.

Tests: new nock unit test, suite 11/11. Version bumped to 2.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)