### PR TITLE
Fix Eddi temperature probe 1 field name (tp -> tp1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "myenergi-api",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "myenergi-api",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "license": "MIT",
             "devDependencies": {
                 "@jest/test-sequencer": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "myenergi-api",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "description": "NodeJS implementation of MyEnergi API for controlling Zappi, Eddi and other MyEnergi products",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/models/Eddi.ts
+++ b/src/models/Eddi.ts
@@ -27,7 +27,7 @@ export interface Eddi {
     rbt: number; // If boosting, the remaining boost time in of seconds
     sta: number; // Status 1=Paused, 3=Diverting, 4=Boost, 5=Max Temp Reached, 6=Stopped
     tim: string; // time
-    tp: number; // temperature probe 1 (50 C)
+    tp1: number; // temperature probe 1 (50 C)
     tp2: number; // temperature probe 2
     vol: number; // Voltage out (divide by 10)
 }


### PR DESCRIPTION
The API reports temp probes as `tp1`/`tp2` (127 or -1 = invalid); the model's `tp` typo made probe 1 inaccessible. Needed for bisand/net.biseth.myenergi#65. Version bumped to 2.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)