### PR TITLE
Add Libbi home battery support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "myenergi-api",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "myenergi-api",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "license": "MIT",
             "devDependencies": {
                 "@jest/test-sequencer": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "myenergi-api",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "description": "NodeJS implementation of MyEnergi API for controlling Zappi, Eddi and other MyEnergi products",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/MyEnergi.ts
+++ b/src/MyEnergi.ts
@@ -4,8 +4,9 @@ import { AppKeyValues } from './models/AppKeyValues';
 import { Eddi } from "./models/Eddi";
 import { Harvi } from "./models/Harvi";
 import { HistoryRecord } from './models/HistoryRecord';
+import { Libbi } from "./models/Libbi";
 import { KeyValue } from './models/KeyValue';
-import { EddiBoost, EddiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting } from "./models/Types";
+import { EddiBoost, EddiMode, LibbiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting } from "./models/Types";
 import { Zappi } from "./models/Zappi";
 
 export class MyEnergi {
@@ -16,6 +17,8 @@ export class MyEnergi {
         eddi_url: "/cgi-jstatus-E",
         zappi_url: "/cgi-jstatus-Z",
         harvi_url: "/cgi-jstatus-H",
+        libbi_url: "/cgi-jstatus-L",
+        libbi_mode_url: "/cgi-libbi-mode-L",
         status_url: "/cgi-jstatus-*",
         dayhour_url: "/cgi-jdayhour-",
         zappi_mode_url: "/cgi-zappi-mode-Z",
@@ -159,6 +162,48 @@ export class MyEnergi {
             return Array.isArray(records) ? records as HistoryRecord[] : [];
         } catch (error) {
             return [];
+        }
+    }
+
+    public async getStatusLibbiAll(): Promise<Libbi[]> {
+        try {
+            const data = await this._digest.get(new URL(this._config.libbi_url, this._config.base_url)) as string;
+            const jsonData = JSON.parse(data);
+            if (jsonData.libbi) return Object.assign<Libbi[], unknown>([] as Libbi[], jsonData.libbi);
+            else return [] as Libbi[];
+        } catch (error) {
+            return [] as Libbi[];
+        }
+    }
+
+    public async getStatusLibbi(serialNumber: string): Promise<Libbi | null> {
+        try {
+            const data = await this._digest.get(new URL(this._config.libbi_url, this._config.base_url)) as string;
+            const jsonData = JSON.parse(data);
+            if (jsonData.libbi) {
+                const libbi = (Object.assign<Libbi[], unknown>([] as Libbi[], jsonData.libbi) as Libbi[]).find((libbi) => {
+                    return libbi.sno == serialNumber;
+                });
+                if (libbi) return Object.assign<Libbi, unknown>({} as Libbi, libbi);
+                else return null;
+            } else return null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    /**
+     * Set the Libbi operating mode. Only Stop, Normal (BALANCE) and
+     * Export (DRAIN) can be set through this API.
+     */
+    public async setLibbiMode(serialNo: string, mode: LibbiMode): Promise<any> {
+        try {
+            const url = new URL(`${this._config.libbi_mode_url}${serialNo}-${mode}`, this._config.base_url);
+            const data = await this._digest.get(url);
+            const jsonData = JSON.parse(data);
+            return jsonData;
+        } catch (error) {
+            return {};
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Eddi } from "./models/Eddi";
 import { Harvi } from "./models/Harvi";
 import { HistoryRecord } from "./models/HistoryRecord";
-import { EddiBoost, EddiHeaterStatus, EddiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus } from "./models/Types";
+import { Libbi } from "./models/Libbi";
+import { EddiBoost, EddiHeaterStatus, EddiMode, LibbiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus } from "./models/Types";
 import { Zappi } from "./models/Zappi";
 import { MyEnergi } from "./MyEnergi";
-export { MyEnergi, Eddi, Zappi, Harvi, HistoryRecord, EddiBoost, EddiMode, EddiHeaterStatus, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus };
+export { MyEnergi, Eddi, Zappi, Harvi, Libbi, HistoryRecord, EddiBoost, EddiMode, EddiHeaterStatus, LibbiMode, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus };

--- a/src/models/Libbi.ts
+++ b/src/models/Libbi.ts
@@ -1,0 +1,42 @@
+/**
+ * Status data for a myenergi Libbi home battery as reported by
+ * cgi-jstatus-L. Zero-valued fields are omitted by the server.
+ */
+export interface Libbi {
+    sno: string;
+    dat: string;
+    tim: string;
+    ectp1: number; // physical CT connection 1 value (Watts)
+    ectp2: number;
+    ectp3: number;
+    ectp4: number;
+    ectp5: number;
+    ectp6: number;
+    ectt1: string; // CT 1 type
+    ectt2: string;
+    ectt3: string;
+    ectt4: string;
+    ectt5: string;
+    ectt6: string;
+    cmt: number; // command tries
+    dst: number; // daylight savings time
+    div: number; // diverted (load) power Watts
+    frq: number; // frequency
+    fwv: string; // firmware version
+    gen: number; // generated power Watts (built-in inverter)
+    grd: number; // grid power Watts
+    pha: number; // phase
+    pri: number; // priority
+    sta: number; // state (see Libbi state codes)
+    soc: number; // state of charge percent
+    lmo: string | number; // Libbi mode, e.g. "BALANCE"/"STOP"/"DRAIN" or numeric
+    mbc: number; // max battery capacity (Wh)
+    mic: number; // max inverter capacity (Wh)
+    che: number; // charge energy this session (kWh)
+    tz: number;
+    vol: number; // voltage (0.1 V)
+    bdb?: number; // battery discharge boost
+    newAppAvailable?: boolean;
+    newBootloaderAvailable?: boolean;
+    batteryDischargeEnabled?: boolean;
+}

--- a/src/models/Types.ts
+++ b/src/models/Types.ts
@@ -72,3 +72,20 @@ export enum ZappiPhaseSetting {
      */
     Auto = 2,
 }
+
+export enum LibbiMode {
+    /**
+     * Stop the Libbi.
+     */
+    Stop = 0,
+    /**
+     * Normal operation (BALANCE) - charge from surplus, discharge to match load.
+     */
+    Normal = 1,
+    /**
+     * Export mode (DRAIN) - discharge the battery to the grid.
+     * Note: the myenergi app defines additional modes (capture, charge,
+     * match) but these cannot be set through this API.
+     */
+    Export = 5,
+}

--- a/tests/MyEnergi-spec.ts
+++ b/tests/MyEnergi-spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { MyEnergi } from "../src/MyEnergi";
-import { ZappiPhaseSetting } from "../src/models/Types";
+import { LibbiMode, ZappiPhaseSetting } from "../src/models/Types";
 import nock from "nock";
 import { Zappi } from "../src/models/Zappi";
 import { AppKeyValues } from '../src/models/AppKeyValues';
@@ -219,6 +219,37 @@ describe("MyEnergi Tests", () => {
         const query = new MyEnergi("test", "pwd", "https://test.com");
 
         const res = await query.setZappiPhaseSetting("12345678", ZappiPhaseSetting.Auto);
+        expect(res).toMatchObject({ status: 0, statustext: "" });
+        nock.cleanAll();
+    }, 60000);
+
+    it("Should return a valid Libbi device", async () => {
+        const libbiResponse = {
+            libbi: [
+                { sno: 21234567, dat: "01-07-2026", tim: "12:00:00", soc: 72, gen: 3200, grd: -150, sta: 5, lmo: "BALANCE", mbc: 10200, mic: 5000, frq: 50.01, vol: 2331, pri: 1, cmt: 254 },
+            ],
+        };
+        nock("https://test.com")
+            .defaultReplyHeaders({ "www-authenticate": "Digest realm=Example" })
+            .get("/cgi-jstatus-L")
+            .reply(200, libbiResponse);
+        const query = new MyEnergi("test", "pwd", "https://test.com");
+
+        const res = await query.getStatusLibbi("21234567");
+        expect(res?.soc).toBe(72);
+        expect(res?.gen).toBe(3200);
+        nock.cleanAll();
+    }, 60000);
+
+    it("Should set Libbi mode", async () => {
+        nock("https://test.com")
+            .defaultReplyHeaders({ "www-authenticate": "Digest realm=Example" })
+            .get("/cgi-libbi-mode-L21234567-1")
+            .reply(200, { status: 0, statustext: "" });
+
+        const query = new MyEnergi("test", "pwd", "https://test.com");
+
+        const res = await query.setLibbiMode("21234567", LibbiMode.Normal);
         expect(res).toMatchObject({ status: 0, statustext: "" });
         nock.cleanAll();
     }, 60000);


### PR DESCRIPTION
Adds the Libbi model, `getStatusLibbiAll`/`getStatusLibbi` and `setLibbiMode` (Stop/Normal/Export via `cgi-libbi-mode`), matching pymyenergi's community-proven implementation. Needed for bisand/net.biseth.myenergi#81 / #74. Version 2.8.0; tests 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)