### PR TITLE
fix: EddiBoost heater 2 used heater 1 command codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "myenergi-api",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "myenergi-api",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "license": "MIT",
             "devDependencies": {
                 "@jest/test-sequencer": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "myenergi-api",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "description": "NodeJS implementation of MyEnergi API for controlling Zappi, Eddi and other MyEnergi products",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/models/Types.ts
+++ b/src/models/Types.ts
@@ -1,10 +1,10 @@
 export enum EddiBoost {
     CancelHeater1 = "1-1",
-    CancelHeater2 = "1-1",
+    CancelHeater2 = "1-2",
     CancelRelay1 = "1-11",
     CancelRelay2 = "1-12",
     ManualHeater1 = "10-1",
-    ManualHeater2 = "10-1",
+    ManualHeater2 = "10-2",
     ManualRelay1 = "10-11",
     ManualRelay2 = "10-12",
 }

--- a/tests/MyEnergi-spec.ts
+++ b/tests/MyEnergi-spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { MyEnergi } from "../src/MyEnergi";
-import { LibbiMode, ZappiPhaseSetting } from "../src/models/Types";
+import { EddiBoost, LibbiMode, ZappiPhaseSetting } from "../src/models/Types";
 import nock from "nock";
 import { Zappi } from "../src/models/Zappi";
 import { AppKeyValues } from '../src/models/AppKeyValues';
@@ -219,6 +219,32 @@ describe("MyEnergi Tests", () => {
         const query = new MyEnergi("test", "pwd", "https://test.com");
 
         const res = await query.setZappiPhaseSetting("12345678", ZappiPhaseSetting.Auto);
+        expect(res).toMatchObject({ status: 0, statustext: "" });
+        nock.cleanAll();
+    }, 60000);
+
+    it("Should start Eddi manual boost on heater 2", async () => {
+        nock("https://test.com")
+            .defaultReplyHeaders({ "www-authenticate": "Digest realm=Example" })
+            .get("/cgi-eddi-boost-E12345678-10-2-60")
+            .reply(200, { status: 0, statustext: "" });
+
+        const query = new MyEnergi("test", "pwd", "https://test.com");
+
+        const res = await query.setEddiBoost("12345678", EddiBoost.ManualHeater2, 60);
+        expect(res).toMatchObject({ status: 0, statustext: "" });
+        nock.cleanAll();
+    }, 60000);
+
+    it("Should cancel Eddi boost on heater 2", async () => {
+        nock("https://test.com")
+            .defaultReplyHeaders({ "www-authenticate": "Digest realm=Example" })
+            .get("/cgi-eddi-boost-E12345678-1-2-0")
+            .reply(200, { status: 0, statustext: "" });
+
+        const query = new MyEnergi("test", "pwd", "https://test.com");
+
+        const res = await query.setEddiBoost("12345678", EddiBoost.CancelHeater2);
         expect(res).toMatchObject({ status: 0, statustext: "" });
         nock.cleanAll();
     }, 60000);


### PR DESCRIPTION
`EddiBoost.CancelHeater2` and `EddiBoost.ManualHeater2` were copy-paste duplicates of the heater 1 values (`1-1`/`10-1`), so any boost targeting heater 2 was silently sent to heater 1. Corrected to `1-2`/`10-2` per the `cgi-eddi-boost-E<sn>-<BoostOn>-<HeaterNo>-<Minutes>` heater numbering (1, 2, 11=relay 1, 12=relay 2).

Adds URL-level nock tests for manual boost and cancel on heater 2. Version bumped to 2.8.1.

Needed by bisand/net.biseth.myenergi#104 (Eddi boost flow cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)